### PR TITLE
Fix not authorized message

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -64,7 +64,9 @@ module.exports.authenticate = (params) => {
         })
         .then((decoded)=> ({
             principalId: decoded.sub,
-            policyDocument: getPolicyDocument('Allow', params.methodArn),
+            // policyDocument: getPolicyDocument('Allow', params.methodArn.split('/').slice(0, 2).join('/') + '/*'),
+            policyDocument: getPolicyDocument('Allow', '*'),
+
             context: { scope: decoded.scope }
         }));
 }


### PR DESCRIPTION
Fix {“Message”:“User is not authorized to access this resource”}
See https://community.auth0.com/t/aws-authorizer-possible-caching-issue/11825